### PR TITLE
fix(docs): use correct link to installation guide

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -6,6 +6,6 @@ displayed_sidebar: documentationSidebar
 # Overview
 
 To begin utilization of the DWCJ, it is recommended you follow one of the
-**[installation guides](http://localhost:3000/docs/category/installation)** to
+**[installation guides](/docs/installation)** to
 help you set up your environment, download BBj, and configure the DWCJ.
 


### PR DESCRIPTION
Hello folks at dwc!

I fixed a link on the intro page that pointed to localhost:3000.
I think this should be the correct one.

Cheers from Düsseldorf

Holger